### PR TITLE
Change 'Get Account Here' to 'Register for Account'

### DIFF
--- a/pages/SignIn.vue
+++ b/pages/SignIn.vue
@@ -50,7 +50,7 @@
                           text
                           to="/signup"
                           class="title secondary--text text-capitalize"
-                        >Get Account Here</v-btn>
+                        >Register for Account</v-btn>
                       </v-col>
                       <v-col cols="12" class="text-center py-0">
                         <ForgotPassword />


### PR DESCRIPTION
# Change 'Get Account Here' to 'Register for Account'

## Summary
Updated the button text on the sign-in page from "Get Account Here" to "Register for Account" to improve clarity and user experience. This is a simple cosmetic change that makes the call-to-action more explicit for new users.

**Changed:**
- `pages/SignIn.vue`: Updated button text on line 53

The button functionality remains unchanged - it still navigates to `/signup` route for account registration.

## Review & Testing Checklist for Human
- [ ] Verify the new "Register for Account" text displays correctly on the sign-in page
- [ ] Test that clicking the button still navigates to the signup page successfully  
- [ ] Confirm no other instances of "Get Account Here" text exist elsewhere in the application

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    SignInPage["pages/SignIn.vue<br/>Sign-in form page"]:::major-edit
    SignUpPage["pages/SignUp.vue<br/>Account registration"]:::context
    
    SignInPage -->|"Register for Account<br/>button navigates to"| SignUpPage
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- Only one instance of "Get Account Here" was found in the codebase during search
- This change improves UX by making the registration call-to-action more explicit
- No functional changes - purely cosmetic text update

Link to Devin run: https://app.devin.ai/sessions/71d9ed78ca3e4429955b64d6f0dd514b
Requested by: Hunter Nunnery (@hnunnery)